### PR TITLE
Update all dependencies

### DIFF
--- a/Reports/WPQA.php
+++ b/Reports/WPQA.php
@@ -3,7 +3,7 @@
  * WPQA Report for PHP_CodeSniffer.
  *
  * @package WPQA
- * @author  Juliette Reinders Folmer <phpcompatibility_nospam@adviesenzo.nl>
+ * @author  Juliette Reinders Folmer <qawp_projects_nospam@adviesenzo.nl>
  */
 
 namespace WPQA;
@@ -39,42 +39,42 @@ class WPQA implements Report {
 	 * @var array
 	 */
 	protected $categorization_basic = array(
-		'Generic.PHP.Syntax'                           => 'hard errors',
-		'Generic.Files.ByteOrderMark'                  => 'hard errors',
+		'Generic.PHP.Syntax'                                    => 'hard errors',
+		'Generic.Files.ByteOrderMark'                           => 'hard errors',
 
-		'Squiz.PHP.Eval'                               => 'dangerous code',
-		'PHPCompatibility.PHP.PregReplaceEModifier'    => 'dangerous code',
-		'Generic.PHP.BacktickOperator'                 => 'dangerous code',
+		'Squiz.PHP.Eval'                                        => 'dangerous code',
+		'PHPCompatibility.ParameterValues.RemovedPCREModifiers' => 'dangerous code',
+		'Generic.PHP.BacktickOperator'                          => 'dangerous code',
 
-		'Generic.Metrics.CyclomaticComplexity'         => 'untestable code',
-		'Generic.Metrics.NestingLevel'                 => 'untestable code',
+		'Generic.Metrics.CyclomaticComplexity'                  => 'untestable code',
+		'Generic.Metrics.NestingLevel'                          => 'untestable code',
 
-		'Generic.Functions.CallTimePassByReference'    => 'outdated code',
-		'Generic.PHP.DisallowShortOpenTag'             => 'outdated code',
-		'Generic.PHP.DisallowAlternativePHPTags'       => 'outdated code',
-		'Generic.PHP.ForbiddenFunctions'               => 'outdated code',
-		'WordPress.PHP.RestrictedPHPFunctions'         => 'outdated code',
-		'WordPress.PHP.POSIXFunctions'                 => 'outdated code',
-		'Generic.PHP.DeprecatedFunctions'              => 'outdated code',
+		'Generic.Functions.CallTimePassByReference'             => 'outdated code',
+		'Generic.PHP.DisallowShortOpenTag'                      => 'outdated code',
+		'Generic.PHP.DisallowAlternativePHPTags'                => 'outdated code',
+		'Generic.PHP.ForbiddenFunctions'                        => 'outdated code',
+		'WordPress.PHP.RestrictedPHPFunctions'                  => 'outdated code',
+		'WordPress.PHP.POSIXFunctions'                          => 'outdated code',
+		'Generic.PHP.DeprecatedFunctions'                       => 'outdated code',
 
-		'WordPress.PHP.DontExtract'                    => 'messy code',
-		'WordPress.CodeAnalysis.AssignmentInCondition' => 'messy code',
-		'Generic.Classes.DuplicateClassName'           => 'messy code',
-		'Generic.CodeAnalysis.JumbledIncrementer'      => 'messy code',
-		'Squiz.Functions.FunctionDuplicateArgument'    => 'messy code',
-		'Generic.PHP.DiscourageGoto'                   => 'messy code',
-		'Squiz.Scope.StaticThisUsage'                  => 'messy code',
+		'WordPress.PHP.DontExtract'                             => 'messy code',
+		'WordPress.CodeAnalysis.AssignmentInCondition'          => 'messy code',
+		'Generic.Classes.DuplicateClassName'                    => 'messy code',
+		'Generic.CodeAnalysis.JumbledIncrementer'               => 'messy code',
+		'Squiz.Functions.FunctionDuplicateArgument'             => 'messy code',
+		'Generic.PHP.DiscourageGoto'                            => 'messy code',
+		'Squiz.Scope.StaticThisUsage'                           => 'messy code',
 
-		'PHPCompatibility'                             => 'incompatible code - PHP',
+		'PHPCompatibility'                                      => 'incompatible code - PHP',
 
-		'WordPress.WP.DeprecatedFunctions'             => 'incompatible code - WP',
-		'WordPress.WP.DeprecatedClasses'               => 'incompatible code - WP',
-		'WordPress.WP.DeprecatedParameters'            => 'incompatible code - WP',
-		'WordPress.WP.DeprecatedParameterValues'       => 'incompatible code - WP',
+		'WordPress.WP.DeprecatedFunctions'                      => 'incompatible code - WP',
+		'WordPress.WP.DeprecatedClasses'                        => 'incompatible code - WP',
+		'WordPress.WP.DeprecatedParameters'                     => 'incompatible code - WP',
+		'WordPress.WP.DeprecatedParameterValues'                => 'incompatible code - WP',
 
-		'WordPress.WP.GlobalVariablesOverrride'        => 'potentially conflicting code',
-		'WordPress.WP.EnqueuedResources'               => 'potentially conflicting code',
-		'WordPress.NamingConventions.PrefixAllGlobals' => 'potentially conflicting code',
+		'WordPress.WP.GlobalVariablesOverrride'                 => 'potentially conflicting code',
+		'WordPress.WP.EnqueuedResources'                        => 'potentially conflicting code',
+		'WordPress.NamingConventions.PrefixAllGlobals'          => 'potentially conflicting code',
 	);
 
 	/**
@@ -103,6 +103,7 @@ class WPQA implements Report {
 		'WordPress.PHP.StrictInArray'                      => 'potentially buggy code',
 		'WordPress.DB.PreparedSQLPlaceholders'             => 'potentially buggy code',
 		'WordPress.PHP.PregQuoteDelimiter'                 => 'potentially buggy code',
+		'WordPress.PHP.NoSilencedErrors'                   => 'potentially buggy code',
 
 		'WordPress.CodeAnalysis.EmptyStatement'            => 'sloppy code',
 		'Generic.CodeAnalysis.EmptyStatement'              => 'sloppy code',

--- a/WP-QA-Basic/ruleset.xml
+++ b/WP-QA-Basic/ruleset.xml
@@ -50,7 +50,7 @@
 	</rule>
 
 	<!-- PCRE /e regex modifier. -->
-	<rule ref="PHPCompatibility.PHP.PregReplaceEModifier"/>
+	<rule ref="PHPCompatibility.ParameterValues.RemovedPCREModifiers"/>
 
 	<!-- Use of the backtick operator (execution of shell commands). -->
 	<rule ref="Generic.PHP.BacktickOperator"/>

--- a/WP-QA-Strict/ruleset.xml
+++ b/WP-QA-Strict/ruleset.xml
@@ -87,6 +87,8 @@
 
 	<rule ref="WordPress.PHP.PregQuoteDelimiter"/>
 
+	<rule ref="WordPress.PHP.NoSilencedErrors"/>
+
 
 	<!--
 	##### Sloppy code. ####

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,13 @@
     ],
     "require"    : {
         "php" : ">=5.4",
-        "squizlabs/php_codesniffer": "^3.3.0",
-        "wp-coding-standards/wpcs": "^1.0.0",
-        "phpcompatibility/phpcompatibility-wp": "*",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+        "squizlabs/php_codesniffer": "^3.3.2",
+        "wp-coding-standards/wpcs": "^1.1.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.0.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
     },
     "minimum-stability" : "RC",
+    "prefer-stable": true,
     "support"    : {
         "issues": "https://github.com/jrfnl/QA-WP-Projects/issues",
         "source": "https://github.com/jrfnl/QA-WP-Projects"

--- a/composer.lock
+++ b/composer.lock
@@ -4,33 +4,31 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "303cbf7d301d63757032898aa6b34ac9",
+    "content-hash": "54da257dc1585c48dc8caa6b61e8d301",
     "packages": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.4.4",
+            "version": "v0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08"
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/2e41850d5f7797cbb1af7b030d245b3b24e63a08",
-                "reference": "2e41850d5f7797cbb1af7b030d245b3b24e63a08",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
+                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0",
                 "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "*"
+                "squizlabs/php_codesniffer": "^2|^3"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "wimg/php-compatibility": "^8.0"
-            },
-            "suggest": {
-                "dealerdirect/qa-tools": "All the PHP QA tools you'll need"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -48,13 +46,13 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "f.nijhof@dealerdirect.nl",
-                    "homepage": "http://workingatdealerdirect.eu",
-                    "role": "Developer"
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://workingatdealerdirect.eu",
+            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -72,20 +70,20 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2017-12-06T16:27:17+00:00"
+            "time": "2018-10-26T13:21:45+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "8.2.0",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a"
+                "reference": "e9f4047e5edf53c88f36f1dafc0d49454ce13e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
-                "reference": "eaf613c1a8265bcfd7b0ab690783f2aef519f78a",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/e9f4047e5edf53c88f36f1dafc0d49454ce13e25",
+                "reference": "e9f4047e5edf53c88f36f1dafc0d49454ce13e25",
                 "shasum": ""
             },
             "require": {
@@ -103,49 +101,57 @@
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
-            "autoload": {
-                "psr-4": {
-                    "PHPCompatibility\\": "PHPCompatibility/"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                },
+                {
                     "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
                     "role": "lead"
                 }
             ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility.",
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
             "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
             "keywords": [
                 "compatibility",
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-17T13:42:26+00:00"
+            "time": "2018-10-07T17:38:02+00:00"
         },
         {
-            "name": "phpcompatibility/phpcompatibility-wp",
+            "name": "phpcompatibility/phpcompatibility-paragonie",
             "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "67d89dcef47f351144d24b247aa968f2269162f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b26c84df3ec1d4850d0f22264a4a16482a171996",
-                "reference": "b26c84df3ec1d4850d0f22264a4a16482a171996",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/67d89dcef47f351144d24b247aa968f2269162f7",
+                "reference": "67d89dcef47f351144d24b247aa968f2269162f7",
                 "shasum": ""
             },
             "require": {
-                "phpcompatibility/php-compatibility": "^8.1"
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -163,7 +169,58 @@
                     "role": "lead"
                 }
             ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP version compatibility for WordPress projects.",
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "time": "2018-10-07T17:59:30+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "reference": "cb303f0067cd5b366a41d4fb0e254fb40ff02efd",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
             "homepage": "http://phpcompatibility.com/",
             "keywords": [
                 "compatibility",
@@ -171,20 +228,20 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-07-16T22:10:02+00:00"
+            "time": "2018-10-07T18:31:37+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec"
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/628a481780561150481a9ec74709092b9759b3ec",
-                "reference": "628a481780561150481a9ec74709092b9759b3ec",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/6ad28354c04b364c3c71a34e4a18b629cc3b231e",
+                "reference": "6ad28354c04b364c3c71a34e4a18b629cc3b231e",
                 "shasum": ""
             },
             "require": {
@@ -222,20 +279,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2018-07-26T23:47:18+00:00"
+            "time": "2018-09-23T23:08:17+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "539c6d74e6207daa22b7ea754d6f103e9abb2755"
+                "reference": "46d42828ce7355d8b3776e3171f2bda892d179b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/539c6d74e6207daa22b7ea754d6f103e9abb2755",
-                "reference": "539c6d74e6207daa22b7ea754d6f103e9abb2755",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/46d42828ce7355d8b3776e3171f2bda892d179b4",
+                "reference": "46d42828ce7355d8b3776e3171f2bda892d179b4",
                 "shasum": ""
             },
             "require": {
@@ -265,14 +322,14 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2018-07-25T18:10:35+00:00"
+            "time": "2018-09-10T17:04:05+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "RC",
     "stability-flags": [],
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=5.4"


### PR DESCRIPTION
* PHP_CodeSniffer has released [version 3.3.2](https://github.com/squizlabs/PHP_CodeSniffer/releases).
* WordPressCS has released [version 1.1.0](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases).
* PHPCompatibility has released [version 9.0.0](https://github.com/PHPCompatibility/PHPCompatibility/releases) in combination with [PHPCompatibilityWP 2.0.0](https://github.com/PHPCompatibility/PHPCompatibilityWP/releases).
* The DealerDirect Composer plugin has released [version 0.5.0](https://github.com/Dealerdirect/phpcodesniffer-composer-installer/releases).

Notes:
* WPCS 1.1.0 contains one new interesting sniff `WordPress.PHP.NoSilencedErrors`, which has been added to the "potentially buggy code" group.
* PHPCompatibility 9.0.0 renames all sniffs. Where necessary, references to these sniffs have been updated.