### PR TITLE
Rulesets: add XSD schema attributes & Travis: validate rulesets & composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 
 dist: trusty
 
+language: php
+
 cache:
     apt: true
 
@@ -14,10 +16,14 @@ before_install:
     - export XMLLINT_INDENT="	"
 
 script:
+    # Make sure all packages used are valid.
+    - composer install
+    # Validate the composer.json file.
+    - composer validate --strict
     # Validate the xml files.
     # @link http://xmlsoft.org/xmllint.html
-    - xmllint --noout ./WP-QA-Basic/ruleset.xml
-    - xmllint --noout ./WP-QA-Strict/ruleset.xml
+    - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./WP-QA-Basic/ruleset.xml
+    - xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./WP-QA-Strict/ruleset.xml
     # Check the code-style consistency of the xml files.
     - diff -B ./WP-QA-Basic/ruleset.xml <(xmllint --format "./WP-QA-Basic/ruleset.xml")
     - diff -B ./WP-QA-Strict/ruleset.xml <(xmllint --format "./WP-QA-Strict/ruleset.xml")

--- a/WP-QA-Basic/ruleset.xml
+++ b/WP-QA-Basic/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="WP-QA-Basic" namespace="WPQA">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WP-QA-Basic" namespace="WPQA" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<description>Basic Code Quality checks for WordPress plugins and themes.</description>
 
 	<!-- Autoload the autoloaders of the dependencies. -->

--- a/WP-QA-Strict/ruleset.xml
+++ b/WP-QA-Strict/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="WP-QA-Strict" namespace="WPQA">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="WP-QA-Strict" namespace="WPQA" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
 	<description>Stricter Code Quality checks for WordPress plugins and themes.</description>
 
 	<!-- Autoload the autoloaders of the dependencies. -->


### PR DESCRIPTION
### Rulesets: add XSD schema attributes

As of PHPCS 3.3.2, the schema is up-to-date with the latest features, so rulesets can be properly validated as part of the build process.

### Build/Travis: validate composer and validate rulesets against XSD

* Do a ccomposer install` to make sure there are no conflicts etc.
* Do a `composer validate` to make sure the Composer file is correct.
* Validate the PHPCS rulesets against the ruleset XSD file.