### PR TITLE
Travis: minor tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+os: linux
 
 language: php
 


### PR DESCRIPTION
* Remove the `dist` key and just use the Travis default distro (currently `xenial`).
* Add `os` key.